### PR TITLE
Slice 5: add public Song Catalog experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This stacked branch contains the greenfield foundation, the portable
 [Catalog Exporter](exporter/), the versioned
 [Catalog Import Package contract](contracts/catalog-import/v1/), immutable Catalog
 Importer snapshots, PostgreSQL search, and the Integration Client read API. Public
-discovery and administration arrive in later stacked pull requests tracked by GitHub
-issue #21.
+Song Catalog search, Song Detail, and Projection Preview are also available without an
+account. Catalog administration arrives in the final stacked pull request tracked by
+GitHub issue #21.
 
 ## Quick Start
 
@@ -73,6 +74,19 @@ The versioned API is served under `/api/v1/` with Bearer-key scopes:
 Machine-readable OpenAPI is available at `/api/v1/docs/openapi.json`. Local development
 serves Swagger UI at `/api/v1/docs`; production serves ReDoc at the same entry point.
 Search continuations are opaque server-provided URLs and expire after 24 hours.
+
+## Public Song Catalog
+
+The root route serves the public Song Catalog through Django and Reactivated. Visitors
+can search titles or lyrics, follow snapshot-pinned result continuations, and open
+rights-aware Song Detail pages. Approved and unknown entries include structured lyrics
+and an accessible approximate 16:9 Projection Preview; restricted entries remain
+metadata-only. Empty search input shows guidance rather than dumping the catalog.
+
+Rendered pages reuse the transport-neutral catalog search/read services directly. They
+do not call the Integration Client API, and restricted lyric fields are removed before
+the Reactivated props are serialized. See
+[ADR-0006](docs/adr/0006-public-catalog-presentation.md).
 
 ## Commands
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -12,7 +12,7 @@ from .templates import RenderableTemplate, RequestInvitationPage, SignInPage
 
 class HomePageView(View):
     def get(self, request, *args, **kwargs) -> HttpResponse:
-        return redirect("account_login")
+        return redirect("catalog:search")
 
 
 class SignInView(LoginView):

--- a/apps/catalog/presentation.py
+++ b/apps/catalog/presentation.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.timesince import timesince
+
+from apps.catalog.models import CatalogEntry, CatalogSnapshot, CatalogState, RightsStatus
+from apps.catalog.search import CatalogReadError, get_active_entry, search_catalog
+
+PUBLIC_DEFAULT_PAGE_SIZE = 20
+PUBLIC_MAX_PAGE_SIZE = 50
+PUBLIC_MAX_QUERY_LENGTH = 128
+LYRIC_PREVIEW_LINES = 3
+LYRIC_PREVIEW_CHARACTERS = 180
+
+
+@dataclass(frozen=True, slots=True)
+class Freshness:
+    """Human- and machine-readable presentation of catalog recency."""
+
+    iso: str
+    absolute: str
+    relative: str
+
+
+@dataclass(frozen=True, slots=True)
+class PublicSearchItem:
+    """Rights-filtered catalog result safe to serialize into a public page."""
+
+    song_uid: str
+    url: str
+    title: str
+    author: str
+    lyric_preview: list[str]
+    lyrics_available: bool
+    rights_status: str
+    song_freshness: Freshness
+
+
+@dataclass(frozen=True, slots=True)
+class PublicSearchResult:
+    """One snapshot-pinned public result page."""
+
+    items: list[PublicSearchItem]
+    catalog_freshness: Freshness | None
+    next_url: str | None
+    has_more: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PublicSection:
+    """One source-ordered Song Section for readable Song Detail."""
+
+    position: int
+    label: str
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class PublicSlide:
+    """One source-ordered projection slide."""
+
+    position: int
+    section_label: str
+    lines: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class PublicSongDetail:
+    """Rights-filtered detail presentation for a Catalog Visitor."""
+
+    song_uid: str
+    title: str
+    authors: list[str]
+    author: str
+    copyright_notice: str
+    rights_status: str
+    lyrics_available: bool
+    sections: list[PublicSection]
+    slides: list[PublicSlide]
+    slide_count: int
+    song_freshness: Freshness
+    catalog_freshness: Freshness | None
+
+
+def _freshness(value: datetime | None) -> Freshness | None:
+    if value is None:
+        return None
+    local_value = timezone.localtime(value)
+    elapsed = timesince(value, timezone.now(), depth=1)
+    return Freshness(
+        iso=value.isoformat(),
+        absolute=local_value.strftime("%B %-d, %Y at %-I:%M %p %Z"),
+        relative=(
+            "just now" if not elapsed or elapsed.startswith("0") else f"{elapsed} ago"
+        ),
+    )
+
+
+def _active_snapshot() -> CatalogSnapshot | None:
+    state = CatalogState.objects.select_related("active_snapshot").filter(pk=1).first()
+    return state.active_snapshot if state else None
+
+
+def _author(entry: CatalogEntry) -> str:
+    authors = [str(author).strip() for author in entry.authors if str(author).strip()]
+    return ", ".join(authors) if authors else "N/A"
+
+
+def _preview(lyrics: str) -> list[str]:
+    lines = [line.strip() for line in lyrics.splitlines() if line.strip()]
+    preview: list[str] = []
+    remaining = LYRIC_PREVIEW_CHARACTERS
+    for line in lines[:LYRIC_PREVIEW_LINES]:
+        if remaining <= 0:
+            break
+        if len(line) > remaining:
+            line = f"{line[: max(remaining - 1, 1)].rstrip()}…"
+        preview.append(line)
+        remaining -= len(line)
+    return preview
+
+
+def _public_search_url(
+    *, query: str, mode: str, limit: int, continuation: str | None = None
+) -> str:
+    parameters = {"q": query, "mode": mode}
+    if limit != PUBLIC_DEFAULT_PAGE_SIZE:
+        parameters["limit"] = str(limit)
+    if continuation:
+        parameters["next"] = continuation
+    return f"{reverse('catalog:search')}?{urlencode(parameters)}"
+
+
+def _continuation(next_url: str | None) -> str | None:
+    if not next_url:
+        return None
+    values = parse_qs(urlsplit(next_url).query)
+    return values.get("next", [None])[0]
+
+
+def parse_public_limit(raw_limit: str | None) -> int:
+    """Validate a public page size without leaking ORM coercion errors."""
+
+    if raw_limit in {None, ""}:
+        return PUBLIC_DEFAULT_PAGE_SIZE
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError) as exc:
+        raise CatalogReadError(
+            "invalid_limit",
+            f"Results per page must be between 1 and {PUBLIC_MAX_PAGE_SIZE}.",
+            400,
+        ) from exc
+    if not 1 <= limit <= PUBLIC_MAX_PAGE_SIZE:
+        raise CatalogReadError(
+            "invalid_limit",
+            f"Results per page must be between 1 and {PUBLIC_MAX_PAGE_SIZE}.",
+            400,
+        )
+    return limit
+
+
+def search_public_catalog(
+    *,
+    query: str,
+    mode: str,
+    limit: int,
+    continuation: str | None,
+) -> PublicSearchResult:
+    """Search the public catalog while enforcing browser-specific constraints."""
+
+    normalized_query = query.strip()
+    if len(normalized_query) > PUBLIC_MAX_QUERY_LENGTH:
+        raise CatalogReadError(
+            "query_too_long",
+            f"Search terms may contain at most {PUBLIC_MAX_QUERY_LENGTH} characters.",
+            400,
+        )
+    if mode not in {"title", "lyrics"}:
+        raise CatalogReadError(
+            "invalid_mode",
+            "Choose either Title or Lyrics search.",
+            400,
+        )
+    if not normalized_query:
+        if continuation:
+            raise CatalogReadError(
+                "cursor_query_mismatch",
+                "This continuation does not belong to an empty search.",
+                400,
+            )
+        snapshot = _active_snapshot()
+        return PublicSearchResult(
+            items=[],
+            catalog_freshness=_freshness(snapshot.completed_at) if snapshot else None,
+            next_url=None,
+            has_more=False,
+        )
+
+    page = search_catalog(
+        query=normalized_query,
+        mode=mode,
+        limit=limit,
+        continuation=continuation,
+        minimum_lyrics_query_length=1,
+    )
+    items = []
+    for entry in page.entries:
+        lyrics_available = entry.rights_status != RightsStatus.RESTRICTED
+        song_freshness = _freshness(entry.content_changed_at)
+        assert song_freshness is not None
+        items.append(
+            PublicSearchItem(
+                song_uid=entry.song_uid,
+                url=reverse("catalog:detail", kwargs={"song_uid": entry.song_uid}),
+                title=entry.title,
+                author=_author(entry),
+                lyric_preview=_preview(entry.cleaned_lyrics) if lyrics_available else [],
+                lyrics_available=lyrics_available,
+                rights_status=entry.rights_status,
+                song_freshness=song_freshness,
+            )
+        )
+    token = _continuation(page.next_url)
+    return PublicSearchResult(
+        items=items,
+        catalog_freshness=(
+            _freshness(page.snapshot.completed_at) if page.snapshot else None
+        ),
+        next_url=(
+            _public_search_url(
+                query=normalized_query,
+                mode=mode,
+                limit=limit,
+                continuation=token,
+            )
+            if token
+            else None
+        ),
+        has_more=page.has_more,
+    )
+
+
+def public_restart_url(*, query: str, mode: str, limit: int) -> str:
+    """Return a safe browser restart URL after a stale continuation."""
+
+    safe_mode = mode if mode in {"title", "lyrics"} else "title"
+    safe_query = query.strip()[:PUBLIC_MAX_QUERY_LENGTH]
+    safe_limit = limit if 1 <= limit <= PUBLIC_MAX_PAGE_SIZE else PUBLIC_DEFAULT_PAGE_SIZE
+    return _public_search_url(query=safe_query, mode=safe_mode, limit=safe_limit)
+
+
+def _display_label(label: object) -> str:
+    value = str(label or "").strip()
+    common = {
+        "verse": "Verse",
+        "chorus": "Chorus",
+        "bridge": "Bridge",
+        "pre-chorus": "Pre-Chorus",
+        "intro": "Intro",
+        "interlude": "Interlude",
+        "tag": "Tag",
+        "ending": "Ending",
+    }
+    return common.get(value.casefold(), value or "Section")
+
+
+def _song_structure(entry: CatalogEntry) -> tuple[list[PublicSection], list[PublicSlide]]:
+    sections: list[PublicSection] = []
+    slides: list[PublicSlide] = []
+    for section_index, raw_section in enumerate(entry.sections, start=1):
+        if not isinstance(raw_section, dict):
+            continue
+        label = _display_label(raw_section.get("label"))
+        raw_slides = raw_section.get("slides", [])
+        section_lines: list[str] = []
+        if not isinstance(raw_slides, list):
+            raw_slides = []
+        for raw_slide in raw_slides:
+            if not isinstance(raw_slide, dict):
+                continue
+            raw_lines = raw_slide.get("lines", [])
+            lines = (
+                [str(line).strip() for line in raw_lines if str(line).strip()]
+                if isinstance(raw_lines, list)
+                else []
+            )
+            if not lines:
+                continue
+            section_lines.extend(lines)
+            slides.append(
+                PublicSlide(
+                    position=len(slides) + 1,
+                    section_label=label,
+                    lines=lines,
+                )
+            )
+        sections.append(
+            PublicSection(
+                position=int(raw_section.get("position") or section_index),
+                label=label,
+                text="\n".join(section_lines),
+            )
+        )
+    if not slides and entry.cleaned_lyrics.strip():
+        fallback_lines = [
+            line.strip() for line in entry.cleaned_lyrics.splitlines() if line.strip()
+        ]
+        slides = [PublicSlide(position=1, section_label="Song", lines=fallback_lines)]
+        sections = [
+            PublicSection(position=1, label="Song", text="\n".join(fallback_lines))
+        ]
+    return sections, slides
+
+
+def get_public_song(song_uid: str) -> PublicSongDetail:
+    """Return a public Song Detail with restricted lyric fields removed."""
+
+    entry = get_active_entry(song_uid)
+    lyrics_available = entry.rights_status != RightsStatus.RESTRICTED
+    sections, slides = _song_structure(entry) if lyrics_available else ([], [])
+    return PublicSongDetail(
+        song_uid=entry.song_uid,
+        title=entry.title,
+        authors=[str(author) for author in entry.authors if str(author).strip()],
+        author=_author(entry),
+        copyright_notice=entry.copyright_notice,
+        rights_status=entry.rights_status,
+        lyrics_available=lyrics_available,
+        sections=sections,
+        slides=slides,
+        slide_count=len(slides),
+        song_freshness=_freshness(entry.content_changed_at),
+        catalog_freshness=_freshness(entry.snapshot.completed_at),
+    )

--- a/apps/catalog/search.py
+++ b/apps/catalog/search.py
@@ -58,6 +58,7 @@ class CatalogReadError(ValueError):
 class SearchPage:
     """One stable page of Song Catalog entries."""
 
+    snapshot: CatalogSnapshot | None
     entries: list[CatalogEntry]
     next_url: str | None
     has_more: bool
@@ -74,7 +75,13 @@ def build_search_url(
     return f"{SEARCH_PATH}?{urlencode(parameters)}"
 
 
-def _validate_request(query: str, mode: str, limit: int) -> tuple[str, str, int]:
+def _validate_request(
+    query: str,
+    mode: str,
+    limit: int,
+    *,
+    minimum_lyrics_query_length: int,
+) -> tuple[str, str, int]:
     normalized_query = str(query or "").strip()
     if len(normalized_query) > MAX_QUERY_LENGTH:
         raise CatalogReadError(
@@ -94,10 +101,11 @@ def _validate_request(query: str, mode: str, limit: int) -> tuple[str, str, int]
             f"Search limit must be between 1 and {MAX_PAGE_SIZE}.",
             400,
         )
-    if mode == "lyrics" and len(normalized_query) < 3:
+    if mode == "lyrics" and len(normalized_query) < minimum_lyrics_query_length:
         raise CatalogReadError(
             "lyrics_query_too_short",
-            "Lyrics search requires at least three non-whitespace characters.",
+            "Lyrics search requires at least "
+            f"{minimum_lyrics_query_length} non-whitespace characters.",
             400,
         )
     return normalized_query, mode, limit
@@ -245,10 +253,16 @@ def search_catalog(
     limit: int = 20,
     continuation: str | None = None,
     include_restricted_lyrics: bool = False,
+    minimum_lyrics_query_length: int = 3,
 ) -> SearchPage:
     """Search one pinned Song Catalog snapshot with stable keyset pagination."""
 
-    query, mode, limit = _validate_request(query, mode, limit)
+    query, mode, limit = _validate_request(
+        query,
+        mode,
+        limit,
+        minimum_lyrics_query_length=minimum_lyrics_query_length,
+    )
     include_restricted_lyrics = mode == "lyrics" and include_restricted_lyrics
     payload = _decode_cursor(continuation) if continuation else None
     if payload:
@@ -270,7 +284,12 @@ def search_catalog(
         strategy = "all" if not query else "fts"
 
     if snapshot is None:
-        return SearchPage(entries=[], next_url=None, has_more=False)
+        return SearchPage(
+            snapshot=None,
+            entries=[],
+            next_url=None,
+            has_more=False,
+        )
 
     entries = CatalogEntry.objects.filter(snapshot=snapshot)
     entries = _filter_search(
@@ -322,7 +341,12 @@ def search_catalog(
             limit=limit,
             cursor=token,
         )
-    return SearchPage(entries=page_entries, next_url=next_url, has_more=has_more)
+    return SearchPage(
+        snapshot=snapshot,
+        entries=page_entries,
+        next_url=next_url,
+        has_more=has_more,
+    )
 
 
 def get_active_entry(song_uid: str) -> CatalogEntry:

--- a/apps/catalog/templates.py
+++ b/apps/catalog/templates.py
@@ -1,0 +1,70 @@
+from typing import NamedTuple, Protocol
+
+from django.http import HttpRequest
+from django.template.response import TemplateResponse
+from reactivated import template
+
+
+class RenderableTemplate(Protocol):
+    """Protocol for Reactivated template classes with a runtime render method."""
+
+    def render(self, request: HttpRequest) -> TemplateResponse: ...
+
+
+class FreshnessProps(NamedTuple):
+    iso: str
+    absolute: str
+    relative: str
+
+
+class SearchItemProps(NamedTuple):
+    song_uid: str
+    url: str
+    title: str
+    author: str
+    lyric_preview: list[str]
+    lyrics_available: bool
+    rights_status: str
+    song_freshness: FreshnessProps
+
+
+@template
+class CatalogSearchPage(NamedTuple):
+    title: str
+    query: str
+    mode: str
+    limit: int
+    searched: bool
+    results: list[SearchItemProps]
+    catalog_freshness: FreshnessProps | None
+    next_url: str | None
+    has_more: bool
+    error: str | None
+    restart_url: str | None
+
+
+class SectionProps(NamedTuple):
+    position: int
+    label: str
+    text: str
+
+
+class SlideProps(NamedTuple):
+    position: int
+    section_label: str
+    lines: list[str]
+
+
+@template
+class SongDetailPage(NamedTuple):
+    title: str
+    author: str
+    copyright_notice: str
+    rights_status: str
+    lyrics_available: bool
+    sections: list[SectionProps]
+    slides: list[SlideProps]
+    slide_count: int
+    song_freshness: FreshnessProps
+    catalog_freshness: FreshnessProps | None
+    catalog_url: str

--- a/apps/catalog/test_public_catalog.py
+++ b/apps/catalog/test_public_catalog.py
@@ -1,0 +1,291 @@
+import uuid
+from datetime import timedelta
+from html.parser import HTMLParser
+
+from django.contrib.postgres.search import SearchVector
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.catalog.models import (
+    CatalogEntry,
+    CatalogImportRun,
+    CatalogSnapshot,
+    CatalogState,
+    ImportStatus,
+    RightsStatus,
+    SnapshotStatus,
+)
+from apps.catalog.text import SEARCH_CONFIG, normalize_title
+
+FINGERPRINT = f"sha256:{'a' * 64}"
+
+
+class NextLinkParser(HTMLParser):
+    """Extract the public continuation without coupling tests to page markup."""
+
+    def __init__(self):
+        super().__init__()
+        self.href = None
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        if tag == "a" and values.get("data-purpose") == "catalog-next":
+            self.href = values.get("href")
+
+
+class PublicCatalogTests(TestCase):
+    def setUp(self):
+        self.snapshot = self.activate_catalog(
+            [
+                {
+                    "uid": "amazing-grace",
+                    "title": "Amazing Grace",
+                    "authors": ["John Newton"],
+                    "lyrics": "Amazing grace\nHow sweet the sound\nThat saved a soul",
+                    "rights": RightsStatus.UNKNOWN,
+                    "sections": [
+                        {
+                            "position": 1,
+                            "label": "verse",
+                            "slides": [
+                                {
+                                    "position": 1,
+                                    "lines": ["Amazing grace", "How sweet the sound"],
+                                },
+                                {
+                                    "position": 2,
+                                    "lines": ["That saved a soul"],
+                                },
+                            ],
+                        },
+                        {
+                            "position": 2,
+                            "label": "verse",
+                            "slides": [
+                                {
+                                    "position": 1,
+                                    "lines": ["I once was lost", "But now am found"],
+                                }
+                            ],
+                        },
+                        {
+                            "position": 3,
+                            "label": "Refrain (soft)",
+                            "slides": [
+                                {
+                                    "position": 1,
+                                    "lines": ["Sing it softly"],
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "uid": "amazing-mercy",
+                    "title": "Amazing Mercy",
+                    "authors": [],
+                    "lyrics": "Mercy in the morning",
+                    "rights": RightsStatus.APPROVED,
+                },
+                {
+                    "uid": "hidden-song",
+                    "title": "Amazing Hidden Song",
+                    "authors": ["Choir"],
+                    "lyrics": "SECRET REFRAIN MUST NEVER LEAK",
+                    "rights": RightsStatus.RESTRICTED,
+                },
+            ]
+        )
+
+    @staticmethod
+    def activate_catalog(records, *, completed_at=None):
+        completed_at = completed_at or timezone.now()
+        run = CatalogImportRun.objects.create(
+            id=uuid.uuid4(),
+            exporter_instance_id=uuid.uuid4(),
+            contract_version="catalog-import/v1",
+            exporter_version="test",
+            parser_version="test",
+            source_fingerprint=FINGERPRINT,
+            package_sha256=FINGERPRINT,
+            records_fingerprint=FINGERPRINT,
+            package_file="packages/test.zip",
+            report_file="reports/test.json",
+            status=ImportStatus.COMPLETED,
+            song_count=len(records),
+            exporter_created_at=completed_at,
+            completed_at=completed_at,
+        )
+        snapshot = CatalogSnapshot.objects.create(
+            import_run=run,
+            status=SnapshotStatus.COMPLETED,
+            staged_at=completed_at,
+            completed_at=completed_at,
+            entry_count=len(records),
+        )
+        for position, record in enumerate(records, start=1):
+            sections = record.get("sections") or [
+                {
+                    "position": 1,
+                    "label": "verse",
+                    "slides": [
+                        {
+                            "position": 1,
+                            "lines": record["lyrics"].splitlines(),
+                        }
+                    ],
+                }
+            ]
+            CatalogEntry.objects.create(
+                snapshot=snapshot,
+                song_uid=record["uid"],
+                title=record["title"],
+                normalized_title=normalize_title(record["title"]),
+                authors=record.get("authors", []),
+                copyright_notice=record.get("copyright", ""),
+                cleaned_lyrics=record["lyrics"],
+                sections=sections,
+                slide_count=sum(len(section["slides"]) for section in sections),
+                rights_status=record.get("rights", RightsStatus.UNKNOWN),
+                fingerprint_version="song-semantic/v1",
+                semantic_fingerprint=FINGERPRINT,
+                metadata_fingerprint=FINGERPRINT,
+                lyrics_fingerprint=FINGERPRINT,
+                structure_fingerprint=FINGERPRINT,
+                presentation_fingerprint=FINGERPRINT,
+                content_changed_at=record.get("changed_at", completed_at),
+            )
+        snapshot.entries.update(
+            title_search=SearchVector("title", config=SEARCH_CONFIG),
+            lyrics_search=SearchVector("cleaned_lyrics", config=SEARCH_CONFIG),
+        )
+        CatalogState.objects.update_or_create(
+            pk=1,
+            defaults={"active_snapshot": snapshot},
+        )
+        return snapshot
+
+    def test_empty_catalog_search_shows_freshness_and_hints_not_every_song(self):
+        response = self.client.get(reverse("catalog:search"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Catalog refreshed")
+        self.assertContains(response, "Start with what you remember")
+        self.assertNotContains(response, "Amazing Grace")
+
+    def test_public_search_retains_modes_author_fallback_and_rights_omission(self):
+        title_response = self.client.get(
+            reverse("catalog:search"),
+            {"q": "Amazing", "mode": "title"},
+        )
+
+        self.assertEqual(title_response.status_code, 200)
+        self.assertContains(title_response, "Amazing Grace")
+        self.assertContains(title_response, "Amazing Mercy")
+        self.assertContains(title_response, "Amazing Hidden Song")
+        self.assertContains(title_response, "N/A")
+        self.assertContains(title_response, "Lyric preview")
+        self.assertContains(title_response, "Lyrics unavailable for public display")
+        self.assertNotContains(title_response, "SECRET REFRAIN MUST NEVER LEAK")
+
+        lyrics_response = self.client.get(
+            reverse("catalog:search"),
+            {"q": "Mercy", "mode": "lyrics"},
+        )
+        self.assertContains(lyrics_response, "Amazing Mercy")
+        self.assertNotContains(lyrics_response, "Amazing Grace")
+        self.assertNotContains(lyrics_response, "Amazing Hidden Song")
+
+        isolated_response = self.client.get(
+            reverse("catalog:search"),
+            {"q": "morning", "mode": "title"},
+        )
+        self.assertContains(isolated_response, "No songs found")
+        self.assertNotContains(isolated_response, "Amazing Mercy")
+
+    def test_public_search_validates_length_and_keeps_no_result_query(self):
+        too_long = "a" * 129
+        response = self.client.get(
+            reverse("catalog:search"),
+            {"q": too_long, "mode": "title"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "at most 128 characters", status_code=400)
+
+        response = self.client.get(
+            reverse("catalog:search"),
+            {"q": "not in the catalog", "mode": "title"},
+        )
+        self.assertContains(response, "No songs found")
+        self.assertContains(response, "not in the catalog")
+
+    def test_public_continuation_stays_pinned_and_expiry_offers_restart(self):
+        old_snapshot = self.activate_catalog(
+            [
+                {
+                    "uid": f"song-{index:02d}",
+                    "title": f"Song {index:02d}",
+                    "lyrics": f"Line {index}",
+                }
+                for index in range(21)
+            ],
+            completed_at=timezone.now() - timedelta(days=1),
+        )
+        first_page = self.client.get(
+            reverse("catalog:search"),
+            {"q": "Song", "mode": "title"},
+        )
+        parser = NextLinkParser()
+        parser.feed(first_page.content.decode())
+        self.assertIsNotNone(parser.href)
+
+        self.activate_catalog(
+            [{"uid": "song-new", "title": "Song New", "lyrics": "New line"}]
+        )
+        second_page = self.client.get(parser.href)
+        self.assertContains(second_page, "Song 20")
+        self.assertNotContains(second_page, "Song New")
+
+        old_snapshot.delete()
+        expired_page = self.client.get(parser.href)
+        self.assertEqual(expired_page.status_code, 410)
+        self.assertContains(expired_page, "Restart this search", status_code=410)
+
+    def test_song_detail_preserves_sections_and_has_accessible_projection(self):
+        response = self.client.get(
+            reverse("catalog:detail", kwargs={"song_uid": "amazing-grace"})
+        )
+        content = response.content.decode()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Song freshness")
+        self.assertContains(response, "Catalog freshness")
+        self.assertContains(response, "Projection Preview")
+        self.assertContains(response, 'class="projection-stage"')
+        self.assertContains(response, 'aria-live="polite"')
+        self.assertContains(response, "Show next projection slide")
+        self.assertContains(response, 'aria-current="step"')
+        self.assertLess(content.index("Amazing grace"), content.index("I once was lost"))
+        self.assertLess(content.index("I once was lost"), content.index("Sing it softly"))
+        self.assertGreaterEqual(content.count(">Verse<"), 2)
+        self.assertContains(response, "Refrain (soft)")
+
+    def test_restricted_song_detail_is_metadata_only_and_has_no_preview(self):
+        response = self.client.get(
+            reverse("catalog:detail", kwargs={"song_uid": "hidden-song"})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Metadata-only entry")
+        self.assertNotContains(response, "SECRET REFRAIN MUST NEVER LEAK")
+        self.assertNotContains(response, "Projection Preview")
+        self.assertNotContains(response, "projection-stage")
+
+    def test_unknown_song_returns_not_found(self):
+        response = self.client.get(
+            reverse("catalog:detail", kwargs={"song_uid": "missing"})
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/apps/catalog/urls.py
+++ b/apps/catalog/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from apps.catalog.views import CatalogSearchView, SongDetailView
+
+app_name = "catalog"
+
+urlpatterns = [
+    path("", CatalogSearchView.as_view(), name="search"),
+    path("songs/<path:song_uid>/", SongDetailView.as_view(), name="detail"),
+]

--- a/apps/catalog/views.py
+++ b/apps/catalog/views.py
@@ -1,0 +1,136 @@
+from typing import cast
+
+from django.http import Http404, HttpRequest, HttpResponse
+from django.urls import reverse
+from django.views import View
+
+from apps.catalog.presentation import (
+    PUBLIC_DEFAULT_PAGE_SIZE,
+    Freshness,
+    PublicSearchItem,
+    get_public_song,
+    parse_public_limit,
+    public_restart_url,
+    search_public_catalog,
+)
+from apps.catalog.search import CatalogReadError
+from apps.catalog.templates import (
+    CatalogSearchPage,
+    FreshnessProps,
+    RenderableTemplate,
+    SearchItemProps,
+    SectionProps,
+    SlideProps,
+    SongDetailPage,
+)
+
+
+def _freshness(value: Freshness | None) -> FreshnessProps | None:
+    if value is None:
+        return None
+    return FreshnessProps(value.iso, value.absolute, value.relative)
+
+
+def _search_item(item: PublicSearchItem) -> SearchItemProps:
+    freshness = _freshness(item.song_freshness)
+    assert freshness is not None
+    return SearchItemProps(
+        song_uid=item.song_uid,
+        url=item.url,
+        title=item.title,
+        author=item.author,
+        lyric_preview=item.lyric_preview,
+        lyrics_available=item.lyrics_available,
+        rights_status=item.rights_status,
+        song_freshness=freshness,
+    )
+
+
+class CatalogSearchView(View):
+    """Render the public Song Catalog search and stable continuations."""
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        query = request.GET.get("q", "")
+        mode = request.GET.get("mode", "title")
+        continuation = request.GET.get("next") or None
+        limit = PUBLIC_DEFAULT_PAGE_SIZE
+        result = None
+        error = None
+        status_code = 200
+        restart_url = None
+        try:
+            limit = parse_public_limit(request.GET.get("limit"))
+            result = search_public_catalog(
+                query=query,
+                mode=mode,
+                limit=limit,
+                continuation=continuation,
+            )
+        except CatalogReadError as exc:
+            error = exc.message
+            status_code = exc.status_code
+            if exc.status_code == 410:
+                restart_url = public_restart_url(
+                    query=query,
+                    mode=mode,
+                    limit=limit,
+                )
+
+        page = cast(
+            RenderableTemplate,
+            CatalogSearchPage(
+                title="Song Catalog",
+                query=query,
+                mode=mode if mode in {"title", "lyrics"} else "title",
+                limit=limit,
+                searched=bool(query.strip()),
+                results=[_search_item(item) for item in result.items] if result else [],
+                catalog_freshness=(
+                    _freshness(result.catalog_freshness) if result else None
+                ),
+                next_url=result.next_url if result else None,
+                has_more=result.has_more if result else False,
+                error=error,
+                restart_url=restart_url,
+            ),
+        )
+        response = page.render(request)
+        response.status_code = status_code
+        return response
+
+
+class SongDetailView(View):
+    """Render one active Song Catalog entry with rights-aware lyric fields."""
+
+    def get(self, request: HttpRequest, song_uid: str) -> HttpResponse:
+        try:
+            song = get_public_song(song_uid)
+        except CatalogReadError as exc:
+            if exc.status_code == 404:
+                raise Http404(exc.message) from exc
+            raise
+        song_freshness = _freshness(song.song_freshness)
+        assert song_freshness is not None
+        page = cast(
+            RenderableTemplate,
+            SongDetailPage(
+                title=song.title,
+                author=song.author,
+                copyright_notice=song.copyright_notice,
+                rights_status=song.rights_status,
+                lyrics_available=song.lyrics_available,
+                sections=[
+                    SectionProps(section.position, section.label, section.text)
+                    for section in song.sections
+                ],
+                slides=[
+                    SlideProps(slide.position, slide.section_label, slide.lines)
+                    for slide in song.slides
+                ],
+                slide_count=song.slide_count,
+                song_freshness=song_freshness,
+                catalog_freshness=_freshness(song.catalog_freshness),
+                catalog_url=reverse("catalog:search"),
+            ),
+        )
+        return page.render(request)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -32,5 +32,6 @@ urlpatterns = [
     path("accounts/login/", SignInView.as_view(), name="account_login"),
     path("invitations/", include("invitations.urls", namespace="invitations")),
     path("accounts/", include("allauth.urls")),
+    path("", include("apps.catalog.urls")),
     path("", include("apps.accounts.urls")),
 ]

--- a/client/Layout.tsx
+++ b/client/Layout.tsx
@@ -4,6 +4,7 @@ import { Context, CSRFToken, reverse } from "@reactivated";
 interface Props {
   title: string;
   children?: React.ReactNode;
+  signedOutHeaderLink?: "staff-sign-in" | "song-search";
 }
 
 // Development-only: Critical inline CSS to prevent Flash of Unstyled Content (FOUC)
@@ -34,6 +35,9 @@ const devCriticalCSS = `
 
 export const Layout = (props: Props) => {
   const { STATIC_URL, user } = React.useContext(Context);
+  const signedOutHeaderLink = props.signedOutHeaderLink === "song-search"
+    ? {href: reverse("catalog:search"), label: "Song search"}
+    : {href: reverse("account_login"), label: "Staff sign in"};
 
   // Only apply FOUC prevention in development
   // In production, Reactivated generates a blocking <link> tag, so CSS loads before paint
@@ -115,10 +119,10 @@ export const Layout = (props: Props) => {
                 </div>
               ) : (
                 <a
-                  href={reverse("account_login")}
+                  href={signedOutHeaderLink.href}
                   className="border-b border-chapel-neutral-400 pb-1 text-[0.65rem] font-bold uppercase tracking-[0.16em] text-chapel-neutral-700 transition-colors hover:border-chapel-primary-500 hover:text-chapel-primary-500 sm:text-xs"
                 >
-                  Staff sign in
+                  {signedOutHeaderLink.label}
                 </a>
               )}
             </div>

--- a/client/Layout.tsx
+++ b/client/Layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Context, CSRFToken } from "@reactivated";
+import { Context, CSRFToken, reverse } from "@reactivated";
 
 interface Props {
   title: string;
@@ -68,11 +68,11 @@ export const Layout = (props: Props) => {
       <body>
         {/* In production, content is visible immediately (no opacity hiding) */}
         <div id="app-content" className={isDev ? "" : "loaded"}>
-          <header className="sticky top-0 z-50 flex h-20 items-center justify-between border-b border-chapel-neutral-300 bg-chapel-neutral-50 px-8 sm:px-12">
+          <header className="sticky top-0 z-50 flex h-20 items-center justify-between border-b border-chapel-neutral-300 bg-chapel-neutral-50/95 px-5 backdrop-blur-md sm:px-12">
             <div className="flex w-1/3 items-center">
-              <span className="text-sm font-bold uppercase tracking-[0.15em] text-chapel-neutral-900">
+              <a href={reverse("catalog:search")} className="text-xs font-bold uppercase tracking-[0.15em] text-chapel-neutral-900 transition-colors hover:text-chapel-primary-500 sm:text-sm">
                 Chapel of Mercy
-              </span>
+              </a>
             </div>
 
             <div className="relative flex w-1/3 justify-center">
@@ -113,7 +113,14 @@ export const Layout = (props: Props) => {
                     </li>
                   </ul>
                 </div>
-              ) : null}
+              ) : (
+                <a
+                  href={reverse("account_login")}
+                  className="border-b border-chapel-neutral-400 pb-1 text-[0.65rem] font-bold uppercase tracking-[0.16em] text-chapel-neutral-700 transition-colors hover:border-chapel-primary-500 hover:text-chapel-primary-500 sm:text-xs"
+                >
+                  Staff sign in
+                </a>
+              )}
             </div>
           </header>
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -138,3 +138,124 @@ a {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
   z-index: 1;
 }
+
+/* Public catalog: a restrained, responsive 16:9 projection preview. */
+.projection-stage {
+  --projection-fit: 1;
+  container-type: inline-size;
+  position: relative;
+  display: grid;
+  aspect-ratio: 16 / 9;
+  place-items: center;
+  overflow: hidden;
+  isolation: isolate;
+  background: var(--color-chapel-secondary-950);
+}
+
+.projection-stage__motion {
+  position: absolute;
+  inset: -18%;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 105%, var(--color-worship-accent-700) 0, var(--color-chapel-primary-800) 20%, transparent 48%),
+    linear-gradient(145deg, var(--color-chapel-secondary-950) 8%, var(--color-chapel-secondary-700) 51%, var(--color-chapel-primary-900) 100%);
+  animation: projection-drift 18s ease-in-out infinite alternate;
+  transform: scale(1.08);
+  z-index: -3;
+}
+
+.projection-stage__glow {
+  position: absolute;
+  width: 56%;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  filter: blur(42px);
+  mix-blend-mode: screen;
+  opacity: 0.5;
+}
+
+.projection-stage__glow--one {
+  left: 4%;
+  top: 8%;
+  background: var(--color-chapel-secondary-400);
+  animation: projection-orbit-one 24s linear infinite;
+}
+
+.projection-stage__glow--two {
+  right: 0;
+  bottom: -18%;
+  background: var(--color-worship-accent-500);
+  animation: projection-orbit-two 29s linear infinite;
+}
+
+.projection-stage__rays {
+  position: absolute;
+  inset: -30%;
+  opacity: 0.24;
+  background: conic-gradient(from 205deg at 50% 100%, transparent 0deg, var(--color-chapel-secondary-100) 7deg, transparent 17deg, transparent 33deg, var(--color-worship-accent-300) 39deg, transparent 48deg);
+  animation: projection-rays 34s linear infinite;
+}
+
+.projection-stage__shade {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 18%, rgb(0 0 0 / 0.42) 100%);
+  z-index: -1;
+}
+
+.projection-stage__lyrics {
+  max-width: 86%;
+  padding: 4cqw;
+  text-align: center;
+  color: white;
+  font-family: var(--font-sans);
+  font-size: clamp(1rem, calc(5.1cqw * var(--projection-fit)), 4rem);
+  font-weight: 700;
+  line-height: 1.18;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+  text-shadow:
+    -1px -1px 0 #000,
+    1px -1px 0 #000,
+    -1px 1px 0 #000,
+    1px 1px 0 #000,
+    0 3px 13px rgb(0 0 0 / 0.88);
+}
+
+.projection-stage__brand {
+  position: absolute;
+  right: 2.5%;
+  bottom: 3.5%;
+  font-size: clamp(0.42rem, 1.2cqw, 0.72rem);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgb(255 255 255 / 0.5);
+}
+
+@keyframes projection-drift {
+  from { transform: scale(1.08) translate3d(-1.8%, -1%, 0); }
+  to { transform: scale(1.16) translate3d(2%, 1.4%, 0); }
+}
+
+@keyframes projection-orbit-one {
+  to { transform: rotate(360deg) translateX(9%) rotate(-360deg); }
+}
+
+@keyframes projection-orbit-two {
+  to { transform: rotate(-360deg) translateX(12%) rotate(360deg); }
+}
+
+@keyframes projection-rays {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root { scroll-behavior: auto; }
+
+  .projection-stage__motion,
+  .projection-stage__glow,
+  .projection-stage__rays {
+    animation: none;
+  }
+}

--- a/client/templates/CatalogSearchPage.tsx
+++ b/client/templates/CatalogSearchPage.tsx
@@ -40,18 +40,38 @@ type RecentSearch = {
 
 const RECENT_SEARCHES_KEY = "wpp.catalog.recent-searches.v1";
 
+const normalizeRecentQuery = (query: string) => (
+    query.trim().replace(/\s+/gu, " ").normalize("NFKC")
+);
+
+const getRecentSearchKey = (search: RecentSearch) => (
+    `${search.mode}:${search.query.toLowerCase()}`
+);
+
 const validateRecentSearches = (value: unknown): RecentSearch[] => {
     if (!Array.isArray(value)) return [];
-    return value.filter((item): item is RecentSearch => (
-        typeof item === "object"
-        && item !== null
-        && "query" in item
-        && typeof item.query === "string"
-        && item.query.length > 0
-        && item.query.length <= 128
-        && "mode" in item
-        && (item.mode === "title" || item.mode === "lyrics")
-    )).slice(0, 5);
+    const searches: RecentSearch[] = [];
+    const seen = new Set<string>();
+    for (const item of value) {
+        if (
+            typeof item !== "object"
+            || item === null
+            || !("query" in item)
+            || typeof item.query !== "string"
+            || !("mode" in item)
+            || (item.mode !== "title" && item.mode !== "lyrics")
+        ) continue;
+        const search: RecentSearch = {
+            query: normalizeRecentQuery(item.query),
+            mode: item.mode,
+        };
+        const key = getRecentSearchKey(search);
+        if (search.query.length === 0 || search.query.length > 128 || seen.has(key)) continue;
+        searches.push(search);
+        seen.add(key);
+        if (searches.length === 5) break;
+    }
+    return searches;
 };
 
 const SearchGlyph = () => (
@@ -144,32 +164,55 @@ const SearchHints = () => (
     </div>
 );
 
-const RecentSearches = ({query, mode}: {query: string; mode: string}) => {
+const RecentSearches = ({query, mode, shouldRecord}: {query: string; mode: string; shouldRecord: boolean}) => {
     const [searches, setSearches] = React.useState<RecentSearch[]>([]);
 
     React.useEffect(() => {
+        let stored: RecentSearch[] = [];
         try {
-            const stored = validateRecentSearches(JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) ?? "[]"));
-            const normalizedQuery = query.trim();
-            const normalizedMode: RecentSearch["mode"] = mode === "lyrics" ? "lyrics" : "title";
-            const next: RecentSearch[] = normalizedQuery
-                ? [
-                    {query: normalizedQuery, mode: normalizedMode},
-                    ...stored.filter((item) => item.query !== normalizedQuery || item.mode !== normalizedMode),
-                ].slice(0, 5)
-                : stored;
-            localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(next));
-            setSearches(next);
-        } catch {
-            setSearches([]);
+            stored = validateRecentSearches(JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) ?? "[]"));
+        } catch {}
+
+        const current: RecentSearch = {
+            query: normalizeRecentQuery(query),
+            mode: mode === "lyrics" ? "lyrics" : "title",
+        };
+        const canRecord = shouldRecord && current.query.length > 0 && current.query.length <= 128;
+        const currentKey = getRecentSearchKey(current);
+        const next = canRecord
+            ? [current, ...stored.filter((item) => getRecentSearchKey(item) !== currentKey)].slice(0, 5)
+            : stored;
+        setSearches(next);
+
+        if (canRecord) {
+            try {
+                localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(next));
+            } catch {}
         }
-    }, [query, mode]);
+    }, [query, mode, shouldRecord]);
+
+    const clearSearches = () => {
+        try {
+            localStorage.removeItem(RECENT_SEARCHES_KEY);
+        } catch {}
+        setSearches([]);
+    };
 
     if (searches.length === 0) return null;
 
     return (
         <div className="mt-10 border-t border-white/30 pt-6">
-            <h2 className="font-sans text-xs font-bold uppercase tracking-[0.14em] text-worship-accent-200">Recent searches</h2>
+            <div className="flex items-center justify-between gap-4">
+                <h2 className="font-sans text-xs font-bold uppercase tracking-[0.14em] text-worship-accent-200">Recent searches</h2>
+                <button
+                    type="button"
+                    onClick={clearSearches}
+                    className="border-b border-white/40 pb-0.5 text-[0.65rem] font-bold uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-worship-accent-200 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-worship-accent-200"
+                    aria-label="Clear recent searches from this browser"
+                >
+                    Clear
+                </button>
+            </div>
             <ul className="mt-3 divide-y divide-white/20">
                 {searches.map((search) => (
                     <li key={`${search.mode}:${search.query}`}>
@@ -199,7 +242,11 @@ export const Template = (props: CatalogSearchPageProps) => {
                         <p className="mt-6 max-w-md text-sm leading-6 text-white/80">
                             A catalogue of easy worship songs updated weekly.
                         </p>
-                        <RecentSearches query={props.query} mode={props.mode} />
+                        <RecentSearches
+                            query={props.query}
+                            mode={props.mode}
+                            shouldRecord={props.searched && props.error === null}
+                        />
                     </aside>
 
                     <section className="min-w-0 px-6 py-9 sm:px-8 lg:px-12 lg:py-14" aria-labelledby="catalog-results-heading">

--- a/client/templates/CatalogSearchPage.tsx
+++ b/client/templates/CatalogSearchPage.tsx
@@ -33,6 +33,27 @@ type CatalogSearchPageProps = {
     restart_url: string | null;
 };
 
+type RecentSearch = {
+    query: string;
+    mode: "title" | "lyrics";
+};
+
+const RECENT_SEARCHES_KEY = "wpp.catalog.recent-searches.v1";
+
+const validateRecentSearches = (value: unknown): RecentSearch[] => {
+    if (!Array.isArray(value)) return [];
+    return value.filter((item): item is RecentSearch => (
+        typeof item === "object"
+        && item !== null
+        && "query" in item
+        && typeof item.query === "string"
+        && item.query.length > 0
+        && item.query.length <= 128
+        && "mode" in item
+        && (item.mode === "title" || item.mode === "lyrics")
+    )).slice(0, 5);
+};
+
 const SearchGlyph = () => (
     <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
         <circle cx="11" cy="11" r="7" />
@@ -41,7 +62,7 @@ const SearchGlyph = () => (
 );
 
 const FreshnessNote = ({freshness}: {freshness: Freshness | null}) => (
-    <p className="flex items-center gap-3 text-xs font-bold uppercase tracking-[0.14em] text-chapel-neutral-600">
+    <p className="flex items-center justify-end gap-3 text-right text-xs font-bold uppercase tracking-[0.14em] text-chapel-neutral-600">
         <span className="h-2 w-2 rounded-full bg-chapel-primary-500" aria-hidden="true" />
         {freshness ? (
             <span>
@@ -54,11 +75,19 @@ const FreshnessNote = ({freshness}: {freshness: Freshness | null}) => (
 );
 
 const SearchForm = ({props}: {props: CatalogSearchPageProps}) => (
-    <form action={reverse("catalog:search")} method="get" role="search" className="mt-5">
-        <label htmlFor="catalog-query" className="text-xs font-bold uppercase tracking-[0.16em] text-chapel-neutral-600">
-            Search titles or lyrics
-        </label>
-        <div className="mt-2 flex items-end gap-3 border-b-2 border-chapel-neutral-950 focus-within:border-chapel-primary-500">
+    <form action={reverse("catalog:search")} method="get" role="search">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+                <label htmlFor="catalog-query" className="text-xs font-bold uppercase tracking-[0.16em] text-chapel-neutral-600">
+                    Search titles or lyrics
+                </label>
+                <p className="mt-2 font-serif text-base italic leading-6 text-chapel-neutral-600">
+                    Search by name when you know it; search by lyrics when only the words remain.
+                </p>
+            </div>
+            <FreshnessNote freshness={props.catalog_freshness} />
+        </div>
+        <div className="mt-3 flex items-end gap-3 border-b-2 border-chapel-neutral-950 focus-within:border-chapel-primary-500">
             <input
                 id="catalog-query"
                 type="search"
@@ -115,6 +144,49 @@ const SearchHints = () => (
     </div>
 );
 
+const RecentSearches = ({query, mode}: {query: string; mode: string}) => {
+    const [searches, setSearches] = React.useState<RecentSearch[]>([]);
+
+    React.useEffect(() => {
+        try {
+            const stored = validateRecentSearches(JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) ?? "[]"));
+            const normalizedQuery = query.trim();
+            const normalizedMode: RecentSearch["mode"] = mode === "lyrics" ? "lyrics" : "title";
+            const next: RecentSearch[] = normalizedQuery
+                ? [
+                    {query: normalizedQuery, mode: normalizedMode},
+                    ...stored.filter((item) => item.query !== normalizedQuery || item.mode !== normalizedMode),
+                ].slice(0, 5)
+                : stored;
+            localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(next));
+            setSearches(next);
+        } catch {
+            setSearches([]);
+        }
+    }, [query, mode]);
+
+    if (searches.length === 0) return null;
+
+    return (
+        <div className="mt-10 border-t border-white/30 pt-6">
+            <h2 className="font-sans text-xs font-bold uppercase tracking-[0.14em] text-worship-accent-200">Recent searches</h2>
+            <ul className="mt-3 divide-y divide-white/20">
+                {searches.map((search) => (
+                    <li key={`${search.mode}:${search.query}`}>
+                        <a
+                            href={`${reverse("catalog:search")}?q=${encodeURIComponent(search.query)}&mode=${search.mode}`}
+                            className="group flex items-center justify-between gap-3 py-3 text-sm text-white/85 transition-colors hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-worship-accent-200"
+                        >
+                            <span className="min-w-0 truncate">{search.query}</span>
+                            <span className="shrink-0 text-[0.65rem] font-bold uppercase tracking-[0.12em] text-white/55 group-hover:text-worship-accent-200">{search.mode}</span>
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
 export const Template = (props: CatalogSearchPageProps) => {
     const resultLabel = props.results.length === 1 ? "1 song" : `${props.results.length} songs`;
 
@@ -123,26 +195,15 @@ export const Template = (props: CatalogSearchPageProps) => {
             <main className="min-h-[calc(100vh-5rem)] bg-chapel-neutral-50 text-chapel-neutral-950">
                 <div className="mx-auto grid max-w-7xl lg:grid-cols-[19rem_minmax(0,1fr)]">
                     <aside className="border-b border-chapel-primary-700 bg-chapel-primary-500 p-7 text-white lg:min-h-[calc(100vh-5rem)] lg:border-b-0 lg:border-r lg:p-10">
-                        <p className="text-xs font-bold uppercase tracking-[0.18em] text-worship-accent-200">Sanctuary Index</p>
-                        <h1 className="mt-6 max-w-xs text-5xl leading-[0.9] text-balance">Songs for gathering.</h1>
+                        <h1 className="max-w-xs text-5xl leading-[0.9] text-balance">Songs for worship.</h1>
                         <p className="mt-6 max-w-md text-sm leading-6 text-white/80">
-                            A clear, ordered index for the moment before rehearsal, service, or study.
+                            A catalogue of easy worship songs updated weekly.
                         </p>
-                        <div className="mt-8 border-t border-white/30 pt-5 lg:mt-12">
-                            <p className="text-xs font-bold uppercase tracking-[0.14em] text-worship-accent-200">Public edition</p>
-                            <p className="mt-2 text-sm leading-6 text-white/75">Read-only songs prepared for the whole worship community.</p>
-                        </div>
-                        <div className="mt-10 hidden grid-cols-6 gap-x-3 gap-y-2 text-center text-[0.65rem] font-bold text-white/55 lg:grid" aria-hidden="true">
-                            {"ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").map((letter) => <span key={letter}>{letter}</span>)}
-                        </div>
+                        <RecentSearches query={props.query} mode={props.mode} />
                     </aside>
 
                     <section className="min-w-0 px-6 py-9 sm:px-8 lg:px-12 lg:py-14" aria-labelledby="catalog-results-heading">
                         <div className="border-b border-chapel-neutral-300 pb-9">
-                            <FreshnessNote freshness={props.catalog_freshness} />
-                            <p className="mt-5 max-w-2xl text-sm leading-6 text-chapel-neutral-600">
-                                Search by name when you know it. Search by lyrics when only the words remain.
-                            </p>
                             <SearchForm props={props} />
                         </div>
 

--- a/client/templates/CatalogSearchPage.tsx
+++ b/client/templates/CatalogSearchPage.tsx
@@ -1,0 +1,232 @@
+import React from "react";
+import {reverse} from "@reactivated";
+import {Layout} from "../Layout";
+
+type Freshness = {
+    iso: string;
+    absolute: string;
+    relative: string;
+};
+
+type SearchItem = {
+    song_uid: string;
+    url: string;
+    title: string;
+    author: string;
+    lyric_preview: string[];
+    lyrics_available: boolean;
+    rights_status: string;
+    song_freshness: Freshness;
+};
+
+type CatalogSearchPageProps = {
+    title: string;
+    query: string;
+    mode: string;
+    limit: number;
+    searched: boolean;
+    results: SearchItem[];
+    catalog_freshness: Freshness | null;
+    next_url: string | null;
+    has_more: boolean;
+    error: string | null;
+    restart_url: string | null;
+};
+
+const SearchGlyph = () => (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+        <circle cx="11" cy="11" r="7" />
+        <path d="m16.2 16.2 4.1 4.1" />
+    </svg>
+);
+
+const FreshnessNote = ({freshness}: {freshness: Freshness | null}) => (
+    <p className="flex items-center gap-3 text-xs font-bold uppercase tracking-[0.14em] text-chapel-neutral-600">
+        <span className="h-2 w-2 rounded-full bg-chapel-primary-500" aria-hidden="true" />
+        {freshness ? (
+            <span>
+                Catalog refreshed <time dateTime={freshness.iso} title={freshness.absolute}>{freshness.relative}</time>
+            </span>
+        ) : (
+            <span>Catalog awaiting its first import</span>
+        )}
+    </p>
+);
+
+const SearchForm = ({props}: {props: CatalogSearchPageProps}) => (
+    <form action={reverse("catalog:search")} method="get" role="search" className="mt-5">
+        <label htmlFor="catalog-query" className="text-xs font-bold uppercase tracking-[0.16em] text-chapel-neutral-600">
+            Search titles or lyrics
+        </label>
+        <div className="mt-2 flex items-end gap-3 border-b-2 border-chapel-neutral-950 focus-within:border-chapel-primary-500">
+            <input
+                id="catalog-query"
+                type="search"
+                name="q"
+                defaultValue={props.query}
+                maxLength={128}
+                autoComplete="off"
+                placeholder={props.mode === "lyrics" ? "Enter a line you remember" : "Enter a song title"}
+                className="min-w-0 flex-1 border-0 bg-transparent py-4 font-serif text-2xl text-chapel-neutral-950 outline-none placeholder:text-chapel-neutral-400 sm:text-3xl"
+                aria-describedby="catalog-search-help"
+            />
+            <button
+                type="submit"
+                className="mb-3 grid h-11 w-11 shrink-0 place-items-center border border-chapel-neutral-950 text-chapel-neutral-950 transition-colors hover:border-chapel-primary-500 hover:bg-chapel-primary-500 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-chapel-primary-500"
+                aria-label="Search the song catalog"
+            >
+                <SearchGlyph />
+            </button>
+        </div>
+        <fieldset className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-3">
+            <legend className="sr-only">Search in</legend>
+            {(["title", "lyrics"] as const).map((mode) => (
+                <label key={mode} className="flex cursor-pointer items-center gap-2 text-xs font-bold uppercase tracking-[0.14em]">
+                    <input
+                        type="radio"
+                        name="mode"
+                        value={mode}
+                        defaultChecked={props.mode === mode}
+                        className="h-4 w-4 accent-chapel-primary-500"
+                    />
+                    {mode}
+                </label>
+            ))}
+        </fieldset>
+        {props.limit !== 20 && <input type="hidden" name="limit" value={props.limit} />}
+        <p id="catalog-search-help" className="mt-4 max-w-xl text-sm leading-6 text-chapel-neutral-600">
+            Use ordinary words. Capitalization and accents do not affect results.
+        </p>
+    </form>
+);
+
+const SearchHints = () => (
+    <div className="grid gap-px border border-chapel-neutral-300 bg-chapel-neutral-300 sm:grid-cols-3">
+        {[
+            ["Title fragment", "Try two or three words from the song name."],
+            ["Lyric line", "Choose Lyrics when the words are more familiar than the title."],
+            ["Plain language", "No operators or special search syntax are needed."],
+        ].map(([heading, body]) => (
+            <article key={heading} className="bg-chapel-neutral-50 p-5">
+                <h3 className="font-sans text-xs font-bold uppercase tracking-[0.14em]">{heading}</h3>
+                <p className="mt-2 text-sm leading-6 text-chapel-neutral-600">{body}</p>
+            </article>
+        ))}
+    </div>
+);
+
+export const Template = (props: CatalogSearchPageProps) => {
+    const resultLabel = props.results.length === 1 ? "1 song" : `${props.results.length} songs`;
+
+    return (
+        <Layout title={props.title}>
+            <main className="min-h-[calc(100vh-5rem)] bg-chapel-neutral-50 text-chapel-neutral-950">
+                <div className="mx-auto grid max-w-7xl lg:grid-cols-[19rem_minmax(0,1fr)]">
+                    <aside className="border-b border-chapel-primary-700 bg-chapel-primary-500 p-7 text-white lg:min-h-[calc(100vh-5rem)] lg:border-b-0 lg:border-r lg:p-10">
+                        <p className="text-xs font-bold uppercase tracking-[0.18em] text-worship-accent-200">Sanctuary Index</p>
+                        <h1 className="mt-6 max-w-xs text-5xl leading-[0.9] text-balance">Songs for gathering.</h1>
+                        <p className="mt-6 max-w-md text-sm leading-6 text-white/80">
+                            A clear, ordered index for the moment before rehearsal, service, or study.
+                        </p>
+                        <div className="mt-8 border-t border-white/30 pt-5 lg:mt-12">
+                            <p className="text-xs font-bold uppercase tracking-[0.14em] text-worship-accent-200">Public edition</p>
+                            <p className="mt-2 text-sm leading-6 text-white/75">Read-only songs prepared for the whole worship community.</p>
+                        </div>
+                        <div className="mt-10 hidden grid-cols-6 gap-x-3 gap-y-2 text-center text-[0.65rem] font-bold text-white/55 lg:grid" aria-hidden="true">
+                            {"ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").map((letter) => <span key={letter}>{letter}</span>)}
+                        </div>
+                    </aside>
+
+                    <section className="min-w-0 px-6 py-9 sm:px-8 lg:px-12 lg:py-14" aria-labelledby="catalog-results-heading">
+                        <div className="border-b border-chapel-neutral-300 pb-9">
+                            <FreshnessNote freshness={props.catalog_freshness} />
+                            <p className="mt-5 max-w-2xl text-sm leading-6 text-chapel-neutral-600">
+                                Search by name when you know it. Search by lyrics when only the words remain.
+                            </p>
+                            <SearchForm props={props} />
+                        </div>
+
+                        <div className="pt-10">
+                            {props.error ? (
+                                <div role="alert" className="border border-chapel-primary-200 bg-chapel-primary-50 p-6 sm:p-8">
+                                    <p className="text-xs font-bold uppercase tracking-[0.16em] text-chapel-primary-500">Search needs attention</p>
+                                    <h2 id="catalog-results-heading" className="mt-3 text-3xl">We could not continue that search.</h2>
+                                    <p className="mt-3 max-w-2xl text-chapel-neutral-700">{props.error}</p>
+                                    {props.restart_url && (
+                                        <a href={props.restart_url} className="mt-6 inline-flex border-b border-chapel-neutral-950 pb-1 text-xs font-bold uppercase tracking-[0.14em]">
+                                            Restart this search
+                                        </a>
+                                    )}
+                                </div>
+                            ) : !props.searched ? (
+                                <div>
+                                    <div className="mb-7 flex flex-col gap-2 border-b border-chapel-neutral-950 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                                        <h2 id="catalog-results-heading" className="text-4xl">Start with what you remember.</h2>
+                                        <p className="text-sm text-chapel-neutral-500">Three ways to begin</p>
+                                    </div>
+                                    <SearchHints />
+                                </div>
+                            ) : props.results.length === 0 ? (
+                                <div className="max-w-2xl py-8">
+                                    <p className="font-serif text-6xl italic text-chapel-primary-500" aria-hidden="true">0</p>
+                                    <h2 id="catalog-results-heading" className="mt-4 text-4xl">No songs found for “{props.query.trim()}.”</h2>
+                                    <p className="mt-4 leading-7 text-chapel-neutral-600">
+                                        Try fewer words, check the spelling, or switch between Title and Lyrics. Your search remains above.
+                                    </p>
+                                </div>
+                            ) : (
+                                <>
+                                    <div className="flex flex-col gap-3 border-b border-chapel-neutral-950 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                                        <div>
+                                            <p className="text-xs font-bold uppercase tracking-[0.14em] text-chapel-primary-500">Searching {props.mode}</p>
+                                            <h2 id="catalog-results-heading" className="mt-2 text-4xl">Songs for “{props.query.trim()}”</h2>
+                                        </div>
+                                        <p className="shrink-0 text-sm text-chapel-neutral-500">Showing {resultLabel}{props.has_more ? " on this page" : ""}</p>
+                                    </div>
+
+                                    <div className="divide-y divide-chapel-neutral-300">
+                                        {props.results.map((song, index) => (
+                                            <article key={song.song_uid} className="group grid gap-4 py-6 sm:grid-cols-[2.5rem_minmax(0,1fr)_minmax(12rem,0.7fr)_2rem] sm:items-center">
+                                                <span className="font-serif text-lg italic text-chapel-neutral-400" aria-hidden="true">{String(index + 1).padStart(2, "0")}</span>
+                                                <div className="min-w-0">
+                                                    <h3 className="text-3xl leading-none">
+                                                        <a href={song.url} className="decoration-chapel-primary-300 underline-offset-8 transition-colors hover:text-chapel-primary-500 hover:underline focus-visible:underline">
+                                                            {song.title}
+                                                        </a>
+                                                    </h3>
+                                                    <p className="mt-2 text-sm font-semibold text-chapel-neutral-700">Author: {song.author}</p>
+                                                    <p className="mt-1 text-xs text-chapel-neutral-500">
+                                                        Updated <time dateTime={song.song_freshness.iso} title={song.song_freshness.absolute}>{song.song_freshness.relative}</time>
+                                                    </p>
+                                                </div>
+                                                <div className="border-l border-chapel-neutral-300 pl-4 text-sm leading-6 text-chapel-neutral-600">
+                                                    {song.lyrics_available ? (
+                                                        <>
+                                                            <p className="mb-1 text-[0.65rem] font-bold uppercase tracking-[0.14em] text-chapel-neutral-400">Lyric preview</p>
+                                                            {song.lyric_preview.map((line, lineIndex) => <p key={lineIndex}>{line}</p>)}
+                                                        </>
+                                                    ) : (
+                                                        <p className="italic text-chapel-neutral-500">Lyrics unavailable for public display.</p>
+                                                    )}
+                                                </div>
+                                                <span className="hidden text-right text-xl text-chapel-primary-500 transition-transform group-hover:translate-x-1 sm:block" aria-hidden="true">→</span>
+                                            </article>
+                                        ))}
+                                    </div>
+
+                                    {props.next_url && (
+                                        <div className="flex justify-end border-t border-chapel-neutral-950 pt-7">
+                                            <a href={props.next_url} rel="next" data-purpose="catalog-next" className="minimal-btn">
+                                                Continue browsing <span aria-hidden="true" className="ml-3">→</span>
+                                            </a>
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </section>
+                </div>
+            </main>
+        </Layout>
+    );
+};

--- a/client/templates/SignInPage.tsx
+++ b/client/templates/SignInPage.tsx
@@ -67,7 +67,7 @@ export const Template = (props: SignInPageProps) => {
     const nonFieldErrors = props.login_form.errors?.__all__ ?? [];
 
     return (
-        <Layout title={props.title}>
+        <Layout title={props.title} signedOutHeaderLink="song-search">
             <div className="flex min-h-[calc(100vh-5rem)] w-full flex-col lg:flex-row bg-chapel-neutral-50 text-chapel-neutral-950 overflow-hidden">
                 
                 {/* Left Side: Editorial Typography & Imagery */}

--- a/client/templates/SongDetailPage.tsx
+++ b/client/templates/SongDetailPage.tsx
@@ -1,0 +1,189 @@
+import React from "react";
+import {Layout} from "../Layout";
+
+type Freshness = {
+    iso: string;
+    absolute: string;
+    relative: string;
+};
+
+type SongSection = {
+    position: number;
+    label: string;
+    text: string;
+};
+
+type ProjectionSlide = {
+    position: number;
+    section_label: string;
+    lines: string[];
+};
+
+type SongDetailPageProps = {
+    title: string;
+    author: string;
+    copyright_notice: string;
+    rights_status: string;
+    lyrics_available: boolean;
+    sections: SongSection[];
+    slides: ProjectionSlide[];
+    slide_count: number;
+    song_freshness: Freshness;
+    catalog_freshness: Freshness | null;
+    catalog_url: string;
+};
+
+const ProjectionPreview = ({title, slides}: {title: string; slides: ProjectionSlide[]}) => {
+    const [currentIndex, setCurrentIndex] = React.useState(0);
+    const current = slides[currentIndex];
+    const longestLine = Math.max(1, ...slides.flatMap((slide) => slide.lines.map((line) => line.length)));
+    const mostLines = Math.max(1, ...slides.map((slide) => slide.lines.length));
+    const fit = Math.max(0.56, Math.min(1, 34 / longestLine, 5 / mostLines));
+    const fitStyle = {"--projection-fit": fit} as React.CSSProperties;
+
+    const move = (change: number) => {
+        setCurrentIndex((index) => Math.min(Math.max(index + change, 0), slides.length - 1));
+    };
+
+    return (
+        <section className="mt-20 border-t border-chapel-neutral-300 pt-12" aria-labelledby="projection-preview-heading">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <p className="text-xs font-bold uppercase tracking-[0.2em] text-chapel-primary-500">Approximate 16:9 canvas</p>
+                    <h2 id="projection-preview-heading" className="mt-2 text-4xl sm:text-5xl">Projection Preview</h2>
+                </div>
+                <p className="max-w-md text-sm leading-6 text-chapel-neutral-600">A non-editable approximation for judging lyric flow and readability—not a pixel-identical EasyWorship renderer.</p>
+            </div>
+
+            <div className="mt-8 overflow-hidden border border-chapel-neutral-950 bg-black shadow-[0_28px_70px_rgba(15,30,66,0.22)]">
+                <div className="projection-stage" style={fitStyle} aria-label={`Projection slide ${currentIndex + 1} of ${slides.length} for ${title}`}>
+                    <div className="projection-stage__motion" aria-hidden="true">
+                        <span className="projection-stage__glow projection-stage__glow--one" />
+                        <span className="projection-stage__glow projection-stage__glow--two" />
+                        <span className="projection-stage__rays" />
+                    </div>
+                    <div className="projection-stage__shade" aria-hidden="true" />
+                    <div className="projection-stage__lyrics" aria-live="polite" aria-atomic="true">
+                        <span className="sr-only">{current.section_label}. Slide {currentIndex + 1} of {slides.length}.</span>
+                        {current.lines.map((line, index) => <p key={`${current.position}-${index}`}>{line}</p>)}
+                    </div>
+                    <div className="projection-stage__brand" aria-hidden="true">Chapel of Mercy</div>
+                </div>
+
+                <div className="grid gap-5 border-t border-white/15 bg-chapel-secondary-950 px-5 py-5 text-white sm:grid-cols-[auto_1fr_auto] sm:items-center sm:px-7">
+                    <button
+                        type="button"
+                        onClick={() => move(-1)}
+                        disabled={currentIndex === 0}
+                        className="order-2 border border-white/25 px-4 py-3 text-xs font-bold uppercase tracking-[0.14em] transition-colors hover:bg-white hover:text-chapel-secondary-950 disabled:cursor-not-allowed disabled:opacity-35 sm:order-1"
+                        aria-label="Show previous projection slide"
+                    >
+                        ← Previous
+                    </button>
+                    <div className="order-1 text-center sm:order-2">
+                        <p className="text-xs font-bold uppercase tracking-[0.18em] text-worship-accent-300">{current.section_label}</p>
+                        <p className="mt-1 text-sm text-white/60">Slide {currentIndex + 1} of {slides.length}</p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => move(1)}
+                        disabled={currentIndex === slides.length - 1}
+                        className="order-3 border border-white/25 px-4 py-3 text-xs font-bold uppercase tracking-[0.14em] transition-colors hover:bg-white hover:text-chapel-secondary-950 disabled:cursor-not-allowed disabled:opacity-35"
+                        aria-label="Show next projection slide"
+                    >
+                        Next →
+                    </button>
+                </div>
+
+                <div className="flex flex-wrap justify-center gap-2 border-t border-white/10 bg-chapel-secondary-950 px-5 pb-6" aria-label="Choose a projection slide">
+                    {slides.map((slide, index) => (
+                        <button
+                            key={`${slide.position}-${index}`}
+                            type="button"
+                            onClick={() => setCurrentIndex(index)}
+                            aria-label={`Show slide ${index + 1}: ${slide.section_label}`}
+                            aria-current={index === currentIndex ? "step" : undefined}
+                            className="h-2.5 w-8 border border-white/40 transition-colors hover:bg-white/60 aria-[current=step]:border-worship-accent-300 aria-[current=step]:bg-worship-accent-300"
+                        >
+                            <span className="sr-only">Slide {index + 1}</span>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export const Template = (props: SongDetailPageProps) => (
+    <Layout title={`${props.title} — Song Catalog`}>
+        <main className="min-h-[calc(100vh-5rem)] bg-chapel-neutral-50 text-chapel-neutral-950">
+            <section className="relative overflow-hidden border-b border-chapel-neutral-300">
+                <div className="absolute inset-y-0 right-0 hidden w-[38%] bg-chapel-primary-500 lg:block" aria-hidden="true" />
+                <div className="relative mx-auto grid max-w-7xl lg:grid-cols-[1fr_0.55fr]">
+                    <div className="px-6 py-14 lg:px-12 lg:py-24">
+                        <a href={props.catalog_url} className="inline-flex items-center gap-3 text-xs font-bold uppercase tracking-[0.18em] text-chapel-neutral-600 transition-colors hover:text-chapel-primary-500">
+                            <span aria-hidden="true">←</span> Back to search
+                        </a>
+                        <p className="mt-16 text-xs font-bold uppercase tracking-[0.18em] text-chapel-primary-500">Song Detail</p>
+                        <h1 className="mt-4 max-w-4xl text-[clamp(3.7rem,8vw,6rem)] leading-[0.86] tracking-[-0.035em] text-balance">{props.title}</h1>
+                        <p className="mt-8 text-lg font-semibold">Author: {props.author}</p>
+                    </div>
+                    <aside className="relative bg-chapel-secondary-950 px-6 py-12 text-white lg:my-12 lg:bg-transparent lg:px-12 lg:py-16" aria-label="Song information">
+                        <dl className="space-y-7 lg:text-chapel-secondary-950">
+                            <div className="border-b border-current/20 pb-5">
+                                <dt className="text-[0.65rem] font-bold uppercase tracking-[0.2em] opacity-60">Song freshness</dt>
+                                <dd className="mt-2 font-serif text-2xl"><time dateTime={props.song_freshness.iso} title={props.song_freshness.absolute}>{props.song_freshness.relative}</time></dd>
+                            </div>
+                            <div className="border-b border-current/20 pb-5">
+                                <dt className="text-[0.65rem] font-bold uppercase tracking-[0.2em] opacity-60">Catalog freshness</dt>
+                                <dd className="mt-2 font-serif text-2xl">
+                                    {props.catalog_freshness ? <time dateTime={props.catalog_freshness.iso} title={props.catalog_freshness.absolute}>{props.catalog_freshness.relative}</time> : "Awaiting import"}
+                                </dd>
+                            </div>
+                            <div className="border-b border-current/20 pb-5">
+                                <dt className="text-[0.65rem] font-bold uppercase tracking-[0.2em] opacity-60">Lyrics rights status</dt>
+                                <dd className="mt-2 font-serif text-2xl capitalize">{props.rights_status}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-[0.65rem] font-bold uppercase tracking-[0.2em] opacity-60">Projection structure</dt>
+                                <dd className="mt-2 font-serif text-2xl">{props.lyrics_available ? `${props.slide_count} ${props.slide_count === 1 ? "slide" : "slides"}` : "Not available"}</dd>
+                            </div>
+                        </dl>
+                    </aside>
+                </div>
+            </section>
+
+            <div className="mx-auto max-w-6xl px-6 py-14 lg:px-12 lg:py-20">
+                {props.lyrics_available ? (
+                    <>
+                        <section aria-labelledby="song-lyrics-heading">
+                            <div className="grid gap-8 lg:grid-cols-[0.45fr_1fr]">
+                                <div>
+                                    <h2 id="song-lyrics-heading" className="text-5xl">Lyrics</h2>
+                                    <p className="mt-3 text-xs font-bold uppercase tracking-[0.16em] text-chapel-primary-500">Source order preserved</p>
+                                    {props.copyright_notice && <p className="mt-6 max-w-xs text-sm leading-6 text-chapel-neutral-600">{props.copyright_notice}</p>}
+                                </div>
+                                <div className="divide-y divide-chapel-neutral-300 border-t border-chapel-neutral-950">
+                                    {props.sections.map((section) => (
+                                        <article key={`${section.position}-${section.label}`} className="grid gap-5 py-8 sm:grid-cols-[7rem_1fr]">
+                                            <h3 className="font-sans text-xs font-bold uppercase tracking-[0.18em] text-chapel-primary-500">{section.label}</h3>
+                                            <p className="whitespace-pre-line font-serif text-2xl leading-[1.35] sm:text-3xl">{section.text}</p>
+                                        </article>
+                                    ))}
+                                </div>
+                            </div>
+                        </section>
+                        {props.slides.length > 0 && <ProjectionPreview title={props.title} slides={props.slides} />}
+                    </>
+                ) : (
+                    <section className="mx-auto max-w-3xl border border-chapel-primary-500 bg-white p-8" aria-labelledby="restricted-heading">
+                        <p className="text-xs font-bold uppercase tracking-[0.2em] text-chapel-primary-500">Metadata-only entry</p>
+                        <h2 id="restricted-heading" className="mt-3 text-4xl">Lyrics are unavailable for public display.</h2>
+                        <p className="mt-4 max-w-xl leading-7 text-chapel-neutral-600">This song remains discoverable by title and source information, but its lyric text and projected lyric view are withheld under the current Lyrics Rights Status.</p>
+                        {props.copyright_notice && <p className="mt-6 text-sm text-chapel-neutral-500">{props.copyright_notice}</p>}
+                    </section>
+                )}
+            </div>
+        </main>
+    </Layout>
+);

--- a/docs/adr/0006-public-catalog-presentation.md
+++ b/docs/adr/0006-public-catalog-presentation.md
@@ -1,0 +1,90 @@
+# ADR-0006: Render a Rights-Safe Public Catalog with Reactivated
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-01
+
+## Context
+
+Catalog Visitors need public Title and Lyrics search, readable Song Detail, freshness,
+and an approximate Projection Preview. The Integration Client API already exposes the
+same catalog domain through Bearer credentials, but browser pages have different input,
+pagination, presentation, and authentication concerns. In particular, public search
+accepts 1–128 characters, shows hints for empty input, defaults to 20 results, and caps
+pages at 50.
+
+Lyrics Rights Status is also a non-disclosure boundary. Approved and unknown entries
+may expose cleaned lyrics and projection slides; restricted entries must be
+metadata-only. Hiding lyric elements in the browser would still serialize restricted
+content into the page source.
+
+Projection Preview needs enough fidelity to assess line breaks and slide flow without
+becoming a presentation controller or promising pixel-identical EasyWorship output.
+
+## Decision
+
+Serve public catalog pages from Django views and Reactivated template contracts. The
+views call the same transport-neutral catalog search and active-entry services used by
+Django Bolt handlers; browser pages never call the Integration Client API. Keep public
+input and page-size validation in a browser-presentation service while leaving the
+underlying search, ordering, rights filtering, and signed snapshot continuations shared.
+
+Convert API-owned continuation tokens into named public URLs without decoding their
+signed state. Empty input resolves Catalog Freshness and guidance without executing a
+catalog-wide search. A pruned or expired continuation returns 410 with a named public
+restart URL; malformed or mismatched state returns 400.
+
+Project model entries into explicit presentation types before constructing Reactivated
+props. For restricted entries, construct no lyric preview, cleaned lyric, section, or
+slide props. Render metadata-only search and detail states from the remaining safe
+fields.
+
+Render eligible lyrics as ordered Song Sections and flatten their source-ordered slides
+for a client-side Projection Preview. The preview uses a responsive 16:9 CSS canvas,
+song-normalized text fitting, stable motion layers, native buttons, announced current
+slide state, and a reduced-motion fallback. React owns only the current slide index;
+Django continues to own routing, validation, permissions, and content selection. Do not
+add a projection JSON endpoint.
+
+## Alternatives Considered
+
+### Fetch browser pages through the Integration Client API
+
+Rejected because public visitors do not have Bearer credentials and because it would
+couple rendered UI to a machine transport with different query limits, empty-state
+behavior, scopes, errors, and rate limits.
+
+### Serialize all lyrics and hide restricted content in React
+
+Rejected because restricted lyrics would remain recoverable from preloaded props, page
+source, caches, and browser tooling.
+
+### Add a video background asset for Projection Preview
+
+Rejected for V1 because an additional media asset and playback lifecycle are not needed
+to approximate continuous motion. CSS motion stays uninterrupted across slide changes,
+is naturally muted, and has a deterministic reduced-motion state.
+
+### Reproduce EasyWorship rendering exactly
+
+Rejected because available source evidence does not completely resolve presentation
+formatting, and the product requirement is an operational approximation rather than a
+presentation controller.
+
+## Consequences
+
+- Public and Integration Client transports share catalog behavior without calling one
+  another.
+- Restricted lyric content is absent from both rendered HTML and preloaded props.
+- Browser-specific validation can remain tighter than API validation without forking
+  PostgreSQL search behavior.
+- Public pagination remains stable across catalog activation while its snapshot is
+  retained.
+- Projection interaction hydrates in React while its first slide remains server
+  rendered and keyboard accessible.
+- Future visual improvements may use retained source evidence, but a pixel-identical
+  renderer or presentation-control behavior requires a separate decision.


### PR DESCRIPTION
## Summary

- add the public Reactivated Song Catalog search and rights-aware Song Detail routes
- keep Django presentation mapping separate from the transport-neutral catalog read services and Django Bolt API contracts
- preserve structured source order, freshness, author fallback, and snapshot-pinned continuations
- add an accessible, responsive 16:9 projection preview for lyrics that are eligible for public display
- adopt the selected Sanctuary Index design using the Chapel burgundy, neutral, navy, and worship-accent palette

## Public rights behavior

- approved and unknown entries may include lyric previews, structured lyrics, and projection slides
- restricted entries are reduced to metadata before Reactivated serialization, so lyric and projection fields never reach the browser

## Design review

Three local prototype directions were reviewed. Option A, Sanctuary Index, was selected and folded into the production page. The throwaway variants remain available on `codex/prototype/catalog-search-variants`; the decision is recorded on issue #21.

## Verification

- `DJANGO_ENV=test .venv/bin/pytest -q` — 36 passed, 8 subtests passed
- `DJANGO_ENV=test .venv/bin/python manage.py check`
- `.venv/bin/python -m compileall -q apps backend`
- `npm exec build.client`
- desktop and mobile visual review with zero horizontal overflow
- Impeccable UI detector reviewed; the slice-specific warning was resolved

## Stack

This is slice 5 of issue #21 and is intentionally based on `codex/pivot/catalog-read-api` (PR #26). Slice 6 has not started.

Refs #21
