### PR TITLE
fix(catalog): harden production bootstrap

### DIFF
--- a/apps/catalog/api.py
+++ b/apps/catalog/api.py
@@ -214,7 +214,7 @@ async def catalog_import(
     return Response(
         CatalogImportResponse(
             run_id=str(result.run.pk),
-            status=result.run.status,
+            status=str(result.run.status),
         ),
         status_code=201 if result.created else 200,
     )

--- a/apps/catalog/migrations/0004_catalog_administration.py
+++ b/apps/catalog/migrations/0004_catalog_administration.py
@@ -10,9 +10,15 @@ def harden_administration_tables(apps, schema_editor):
         "catalog_catalogsongrights",
         "catalog_lyricsrightschange",
     )
+    quote_name = schema_editor.quote_name
     with schema_editor.connection.cursor() as cursor:
-        for table in tables:
-            cursor.execute(f'ALTER TABLE public."{table}" ENABLE ROW LEVEL SECURITY')
+        cursor.execute("SELECT current_schema()")
+        schema_name = cursor.fetchone()[0]
+        qualified_tables = [
+            f"{quote_name(schema_name)}.{quote_name(table)}" for table in tables
+        ]
+        for table in qualified_tables:
+            cursor.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
         cursor.execute(
             "SELECT rolname FROM pg_catalog.pg_roles "
             "WHERE rolname = ANY(%s)",
@@ -20,8 +26,8 @@ def harden_administration_tables(apps, schema_editor):
         )
         roles = [row[0] for row in cursor.fetchall()]
         if roles:
-            role_list = ", ".join(f'"{role}"' for role in roles)
-            table_list = ", ".join(f'public."{table}"' for table in tables)
+            role_list = ", ".join(quote_name(role) for role in roles)
+            table_list = ", ".join(qualified_tables)
             cursor.execute(
                 f"REVOKE ALL PRIVILEGES ON TABLE {table_list} FROM {role_list}"
             )

--- a/apps/catalog/test_migration_schema.py
+++ b/apps/catalog/test_migration_schema.py
@@ -1,0 +1,77 @@
+import importlib
+from contextlib import nullcontext
+from unittest import TestCase
+
+
+class FakeCursor:
+    def __init__(self):
+        self.statements = []
+        self._result = []
+
+    def execute(self, statement, params=None):
+        self.statements.append((statement, params))
+        if statement.strip() == "SELECT current_schema()":
+            self._result = [("wpp_catalog_v1",)]
+        elif "FROM pg_catalog.pg_roles" in statement:
+            self._result = []
+
+    def fetchone(self):
+        return self._result[0]
+
+    def fetchall(self):
+        return self._result
+
+
+class FakeConnection:
+    vendor = "postgresql"
+
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return nullcontext(self._cursor)
+
+
+class FakeSchemaEditor:
+    def __init__(self, cursor):
+        self.connection = FakeConnection(cursor)
+
+    @staticmethod
+    def quote_name(name):
+        return f'"{name}"'
+
+
+class EmptyApps:
+    @staticmethod
+    def get_models(include_auto_created=True):
+        return []
+
+
+class MigrationSchemaTests(TestCase):
+    def test_catalog_hardening_uses_active_schema(self):
+        migration = importlib.import_module(
+            "apps.catalog.migrations.0004_catalog_administration"
+        )
+        cursor = FakeCursor()
+
+        migration.harden_administration_tables(None, FakeSchemaEditor(cursor))
+
+        sql = "\n".join(statement for statement, _ in cursor.statements)
+        self.assertIn(
+            'ALTER TABLE "wpp_catalog_v1"."catalog_catalogsongrights"', sql
+        )
+        self.assertNotIn("public.catalog_catalogsongrights", sql)
+
+    def test_common_hardening_uses_active_schema(self):
+        migration = importlib.import_module(
+            "apps.common.migrations.0001_harden_supabase_api_exposure"
+        )
+        cursor = FakeCursor()
+
+        migration.harden_supabase_api_exposure(EmptyApps(), FakeSchemaEditor(cursor))
+
+        sql = "\n".join(statement for statement, _ in cursor.statements)
+        self.assertIn(
+            'ALTER TABLE IF EXISTS "wpp_catalog_v1"."django_migrations"', sql
+        )
+        self.assertNotIn("public.django_migrations", sql)

--- a/apps/catalog/tests.py
+++ b/apps/catalog/tests.py
@@ -138,6 +138,7 @@ class CatalogImporterTests(TransactionTestCase):
         package, run_id = self.build_package()
         response = self.post_package(package)
         self.assertEqual(response.status_code, 201)
+        self.assertEqual(json.loads(response.to_bytes())["status"], "completed")
 
         run = CatalogImportRun.objects.get(pk=run_id)
         active_snapshot = CatalogState.objects.get().active_snapshot

--- a/apps/common/migrations/0001_harden_supabase_api_exposure.py
+++ b/apps/common/migrations/0001_harden_supabase_api_exposure.py
@@ -20,6 +20,12 @@ def harden_supabase_api_exposure(apps, schema_editor):
     )
     quote_name = schema_editor.quote_name
     with schema_editor.connection.cursor() as cursor:
+        cursor.execute("SELECT current_schema()")
+        schema_name = cursor.fetchone()[0]
+        qualified_tables = [
+            f"{quote_name(schema_name)}.{quote_name(table_name)}"
+            for table_name in table_names
+        ]
         cursor.execute(
             """
             SELECT rolname
@@ -30,10 +36,9 @@ def harden_supabase_api_exposure(apps, schema_editor):
         )
         existing_roles = {row[0] for row in cursor.fetchall()}
 
-        for table_name in table_names:
+        for table_name in qualified_tables:
             cursor.execute(
-                f"ALTER TABLE IF EXISTS public.{quote_name(table_name)} "
-                "ENABLE ROW LEVEL SECURITY"
+                f"ALTER TABLE IF EXISTS {table_name} ENABLE ROW LEVEL SECURITY"
             )
 
         if not existing_roles:
@@ -42,21 +47,20 @@ def harden_supabase_api_exposure(apps, schema_editor):
         role_list = ", ".join(
             quote_name(role) for role in SUPABASE_API_ROLES if role in existing_roles
         )
-        table_list = ", ".join(
-            f"public.{quote_name(table_name)}" for table_name in table_names
-        )
+        table_list = ", ".join(qualified_tables)
         cursor.execute(f"REVOKE ALL PRIVILEGES ON TABLE {table_list} FROM {role_list}")
         for object_type in ("SEQUENCES", "FUNCTIONS"):
             cursor.execute(
-                f"REVOKE ALL PRIVILEGES ON ALL {object_type} IN SCHEMA public "
+                f"REVOKE ALL PRIVILEGES ON ALL {object_type} IN SCHEMA "
+                f"{quote_name(schema_name)} "
                 f"FROM {role_list}"
             )
             cursor.execute(
-                f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {quote_name(schema_name)} "
                 f"REVOKE ALL PRIVILEGES ON {object_type} FROM {role_list}"
             )
         cursor.execute(
-            f"ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {quote_name(schema_name)} "
             f"REVOKE ALL PRIVILEGES ON TABLES FROM {role_list}"
         )
 

--- a/docs/adr/0008-isolate-greenfield-production-schema.md
+++ b/docs/adr/0008-isolate-greenfield-production-schema.md
@@ -1,0 +1,66 @@
+# ADR-0008: Isolate the Greenfield Catalog Production Schema
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-01
+
+## Context
+
+ADR-0001 deliberately replaces the schedule-oriented product with a greenfield Song
+Catalog and requires an empty PostgreSQL schema. The existing production Supabase
+database still contains the pre-pivot migration ledger, accounts, schedules, and songs.
+Applying the new migration graph to that `public` schema fails because the old
+`account.0001_initial` is recorded before the new `accounts.0001_initial` dependency.
+
+Dropping `public` would satisfy the greenfield requirement but would irreversibly remove
+the legacy production data. Faking migrations or editing the old ledger would couple the
+new product to a history ADR-0001 intentionally archived.
+
+## Decision
+
+Run the production Song Catalog in the dedicated `wpp_catalog_v1` PostgreSQL schema.
+Both `DATABASE_URL` and `DIRECT_URL` put `wpp_catalog_v1` first in `search_path`, with
+`public` second for shared PostgreSQL extensions and the catalog text-search
+configuration. The URL option must encode its space as `%20`, not `+`:
+
+```text
+options=-c%20search_path%3Dwpp_catalog_v1%2Cpublic
+```
+
+Initialize `wpp_catalog_v1.django_migrations` before the first migration so it shadows
+the preserved `public.django_migrations` ledger. Migrations that harden application
+tables must qualify them using `current_schema()` rather than assuming `public`.
+Objects intentionally shared across schemas, such as `public.wpp_simple_unaccent`,
+remain explicitly qualified.
+
+## Alternatives Considered
+
+### Drop and recreate the public schema
+
+Rejected because the pivot does not require destroying the archived product's data, and
+the deployment can meet the empty-schema requirement without that loss.
+
+### Rewrite or fake the legacy migration history
+
+Rejected because matching two unrelated greenfield histories would be fragile and
+would leave the new runtime dependent on tables outside its domain.
+
+### Create a separate Supabase project
+
+Rejected for this deployment because a separate schema provides the required isolation
+while retaining the existing database, storage credentials, and operational footprint.
+
+## Consequences
+
+- Legacy production tables and their migration ledger remain intact in `public`.
+- Song Catalog services, migrations, and administration use only `wpp_catalog_v1` for
+  Django-owned tables.
+- New deployment tooling and database-secret rotations must preserve the encoded
+  `search_path` option on both database URLs.
+- Migration tests must cover non-`public` schemas so hard-coded qualifiers do not recur.
+- Supabase API exposure remains limited because the custom schema is not added to the
+  exposed PostgREST schemas.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -145,6 +145,18 @@ The expected meaning of the database URLs is:
 - `DATABASE_URL`: Supabase pooled connection, used by running services
 - `DIRECT_URL`: Supabase direct `5432` connection, used only by migrations
 
+The existing `worship-prep-portal` production database preserves the pre-pivot tables
+in `public`. Both URLs must therefore target the isolated greenfield schema by including
+this query parameter (append it with `&` when the URL already has a query string):
+
+```text
+options=-c%20search_path%3Dwpp_catalog_v1%2Cpublic
+```
+
+Do not encode the space as `+`; libpq treats that value differently and falls back to
+`public`. See [ADR-0008](adr/0008-isolate-greenfield-production-schema.md) for the
+reasoning and migration-ledger bootstrap requirement.
+
 The expected meaning of the storage variables is:
 
 - `SUPABASE_STORAGE_BUCKET`: the media bucket name, usually `wpp-media`

--- a/exporter/internal/contract/package.go
+++ b/exporter/internal/contract/package.go
@@ -26,6 +26,9 @@ func Build(path string, manifest Manifest, songs []SongRecord) (Manifest, error)
 	encoder := json.NewEncoder(&records)
 	encoder.SetEscapeHTML(false)
 	for _, song := range songs {
+		if song.Sections == nil {
+			song.Sections = []Section{}
+		}
 		if err := encoder.Encode(song); err != nil {
 			return Manifest{}, fmt.Errorf("encode song %q: %w", song.Source.SongUID, err)
 		}

--- a/exporter/internal/contract/package_test.go
+++ b/exporter/internal/contract/package_test.go
@@ -1,0 +1,44 @@
+package contract
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBuildEncodesEmptySectionsAsArray(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "catalog-import.zip")
+	manifest := Manifest{CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)}
+	song := SongRecord{Sections: nil}
+
+	if _, err := Build(path, manifest, []SongRecord{song}); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archive.Close()
+	reader, err := archive.File[1].Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatal(err)
+	}
+	sections, ok := record["sections"].([]any)
+	if !ok || len(sections) != 0 {
+		t.Fatalf("sections = %#v, want []", record["sections"])
+	}
+}

--- a/exporter/internal/rtf/parser.go
+++ b/exporter/internal/rtf/parser.go
@@ -233,7 +233,7 @@ func (p *parser) control() error {
 
 func (p *parser) writeRune(value rune) {
 	current := &p.states[len(p.states)-1]
-	if current.ignored {
+	if current.ignored || value == 0 {
 		return
 	}
 	if current.pendingSkip > 0 && value <= unicode.MaxASCII {

--- a/exporter/internal/rtf/parser_test.go
+++ b/exporter/internal/rtf/parser_test.go
@@ -49,6 +49,17 @@ func TestParseWarnsAboutSlideCardinalityWithoutRejectingSong(t *testing.T) {
 	}
 }
 
+func TestParseDropsNulUnicodeControls(t *testing.T) {
+	t.Parallel()
+	result, err := Parse(`{\rtf1\ansi Before\u0?After}`, nil)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got, want := result.CleanedLyrics, "BeforeAfter"; got != want {
+		t.Fatalf("CleanedLyrics = %q, want %q", got, want)
+	}
+}
+
 func TestParseRejectsUnusableLyrics(t *testing.T) {
 	t.Parallel()
 	if _, err := Parse("plain text", nil); err == nil {

--- a/exporter/internal/source/read.go
+++ b/exporter/internal/source/read.go
@@ -225,6 +225,9 @@ func readSongs(ctx context.Context, database *sql.DB, words map[int64]rawWord) (
 				Code: "structural_anomaly", SongUID: uid, Message: warning,
 			})
 		}
+		if parsed.Sections == nil {
+			parsed.Sections = []contract.Section{}
+		}
 		record := contract.SongRecord{
 			ContractVersion: contract.Version,
 			Source: contract.SongSource{


### PR DESCRIPTION
## What changed

- qualify Supabase hardening migrations with the active PostgreSQL schema
- document the isolated `wpp_catalog_v1` production schema and URL encoding
- encode empty song sections as arrays and ignore non-rendering RTF NUL controls
- serialize catalog import statuses as strings in Django Bolt responses
- add migration, package-contract, parser, and response regressions

## Why

The v1 production deployment encountered the preserved legacy migration ledger in
`public`, authentic backup records with empty sections and RTF `\u0` controls, and a
Django `TextChoices` response that Django Bolt could not encode. These changes preserve
the legacy schema while making the greenfield catalog bootstrap and import path
reproducible.

## Impact

- legacy production data remains intact in `public`
- the v1 catalog runs in `wpp_catalog_v1`
- authentic EasyWorship backups import without JSON null arrays or PostgreSQL NUL errors
- successful and idempotent imports return valid JSON responses

## Validation

- `poe test` — 47 passed
- `go test ./...` — passed
- Cloud Build `9e74669e-e7f7-4d61-82e9-fff9c374eeb8` — succeeded
- production readiness — database and storage OK
- initial import — 2,283 active entries
- exact-package retry — HTTP 200, one snapshot, 2,283 entries
- live title and lyrics search smoke tests — passed
