### PR TITLE
Fix Git-triggered Docker build source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ node_modules/
 .env
 .DS_Store
 
-# React
-patches/
-
 # AI
 .aider*
 .cursor/plans/

--- a/patches/reactivated+0.47.8.patch
+++ b/patches/reactivated+0.47.8.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/reactivated/src/generator.mts b/node_modules/reactivated/src/generator.mts
+index 4ca6c96..6fb06ed 100644
+--- a/node_modules/reactivated/src/generator.mts
++++ b/node_modules/reactivated/src/generator.mts
+@@ -388,6 +388,7 @@ compile(types, "this is unused", {additionalProperties: false}).then(async (ts)
+     const statements = [];
+ 
+     if (!fs.existsSync("./reactivated-skip-template-check")) {
++        statements.push("export namespace templates {}");
+         for (const name of Object.keys(templates)) {
+             const propsName = templates[name];
+ 


### PR DESCRIPTION
## What changed

- stop ignoring the `patches/` directory
- commit the required `reactivated+0.47.8.patch` input

## Why

Cloud Build trigger `50eb2b6c-cb56-4010-91ec-02d5d06984f6` cloned `main` from GitHub and failed at `COPY patches/ ./patches/` because the patch existed only in local workspaces and was ignored by Git. Manual source uploads masked the issue because `.gcloudignore` included the untracked directory.

## Impact

Fresh Git checkouts now contain the source required by the Docker `node-deps` stage, so automatic Cloud Build runs can install dependencies and apply the Reactivated patch.

## Validation

- `git ls-files --error-unmatch patches/reactivated+0.47.8.patch`
- `docker build -f docker/Dockerfile --target=node-deps .`
  - `COPY patches/` succeeded
  - `reactivated@0.47.8` patch applied successfully

## Deployment prerequisite

The production `main` trigger still needs its required substitutions configured (`_RUNTIME_SA`, storage buckets, S3 endpoint, region, and Artifact Registry repository). That external trigger mutation is intentionally not part of this PR.